### PR TITLE
Improve support for mechanisms with loops.

### DIFF
--- a/src/RigidBodyTreeInspector.jl
+++ b/src/RigidBodyTreeInspector.jl
@@ -25,6 +25,7 @@ import Interpolations: interpolate, Linear, Gridded
 import Base: convert, *, one
 import LightXML: XMLElement, parse_file, root, get_elements_by_tagname,
                  attribute, find_element, name
+import Rotations
 import MeshIO
 
 export manipulate,

--- a/src/animate.jl
+++ b/src/animate.jl
@@ -39,7 +39,7 @@ function animate(vis::Visualizer, mechanism::Mechanism{Float64},
     for t in times[1] : dt : times[end]
         tic()
         q = interpolated_configurations[t]
-        for joint in joints(mechanism)
+        for joint in tree_joints(mechanism)
             q_range = RigidBodyDynamics.configuration_range(state, joint)
             q_joint = q[q_range]
             normalize_configuration!(joint.jointType, q_joint)

--- a/src/geometry.jl
+++ b/src/geometry.jl
@@ -1,19 +1,4 @@
-function rotation_between{T}(from::AbstractVector{T}, to::AbstractVector{T})
-    from /= norm(from)
-    to /= norm(to)
-    costheta = dot(from, to)
-    p = cross(from, to)
-    sintheta = norm(p)
-    if sintheta > 0
-        axis = p / sintheta
-        angle = atan2(sintheta, costheta)
-        return AngleAxis(angle, axis[1], axis[2], axis[3])
-    else
-        return AngleAxis(0.0, 1, 0, 0)
-    end
-end
-
-rotation_from_x_axis{T}(translation::AbstractVector{T}) = rotation_between(SVector{3, T}(1,0,0), translation)
+rotation_from_x_axis{T}(translation::AbstractVector{T}) = Rotations.rotation_between(SVector{3, T}(1,0,0), translation)
 
 function inertial_ellipsoid_dimensions(mass, axis_inertias)
     # Ix = m/5 (dy^2 + dz^2)

--- a/src/geometry.jl
+++ b/src/geometry.jl
@@ -67,10 +67,12 @@ function inertial_ellipsoid(mechanism::Mechanism, body::RigidBody)
 end
 
 function create_frame_to_frame_geometry(mechanism, body, frame1, frame2, radius)
+    T = eltype(mechanism)
     joint_to_joint = fixed_transform(mechanism, frame1, frame2)
     trans = translation(joint_to_joint)
-    Rx = rotation_from_x_axis(trans)
     geom_length = norm(trans)
+    Rx = geom_length > 1e-10 ? rotation_from_x_axis(trans) : eye(Rotations.RotMatrix{3, T})
+
     joint_to_geometry_origin = compose(compose(LinearMap(Rx),
                                                Translation(geom_length / 2, 0, 0)),
                                        LinearMap(AngleAxis(pi/2, 0, 1, 0)))

--- a/src/geometry.jl
+++ b/src/geometry.jl
@@ -81,8 +81,8 @@ function inertial_ellipsoid(mechanism::Mechanism, body::RigidBody)
     return geometry, principal_axes_com_frame
 end
 
-function create_geometry_for_translation(mechanism, body, joint, radius)
-    joint_to_joint = fixed_transform(mechanism, joint.frameBefore, default_frame(body))
+function create_frame_to_frame_geometry(mechanism, body, frame1, frame2, radius)
+    joint_to_joint = fixed_transform(mechanism, frame1, frame2)
     trans = translation(joint_to_joint)
     Rx = rotation_from_x_axis(trans)
     geom_length = norm(trans)
@@ -90,28 +90,33 @@ function create_geometry_for_translation(mechanism, body, joint, radius)
                                                Translation(geom_length / 2, 0, 0)),
                                        LinearMap(AngleAxis(pi/2, 0, 1, 0)))
     frame = CartesianFrame3D("$(RigidBodyDynamics.name(body)) joint-to-joint translation")
-    tform = Transform3D(frame, default_frame(body),
+    tform = Transform3D(frame, joint_to_joint.to,
                         joint_to_geometry_origin.m,
                         joint_to_geometry_origin.v)
     add_frame!(body, tform)
-    return HyperCylinder{3, Float64}(geom_length, radius), frame
+    HyperCylinder{3, Float64}(geom_length, radius), frame
 end
 
-function maximum_link_length{T}(mechanism::Mechanism{T})
+function maximum_link_length{T}(body_fixed_joint_frames::Dict{RigidBody{T}, Vector{CartesianFrame3D}})
     result = zero(T)
-    for joint in tree_joints(mechanism)
-        parent_default_frame = default_frame(predecessor(joint, mechanism))
-        transform = fixed_transform(mechanism, parent_default_frame, frame_before(joint))
-        result = max(result, norm(translation(transform)))
+    for (body, joint_frames) in body_fixed_joint_frames
+        for framei in joint_frames, framej in joint_frames
+            transform = fixed_transform(body, framei, framej)
+            result = max(result, norm(translation(transform)))
+        end
     end
     result
 end
 
 function create_geometry(mechanism; show_inertias::Bool=false, randomize_colors::Bool=true)
-    box_width = 0.05 * maximum_link_length(mechanism)
+    body_fixed_joint_frames = Dict(body => begin
+        [map(frame_before, out_joints(body, mechanism)); map(frame_after, in_joints(body, mechanism))]
+    end for body in bodies(mechanism))
 
+    box_width = 0.05 * maximum_link_length(body_fixed_joint_frames)
     vis_data = OrderedDict{CartesianFrame3D, Vector{GeometryData}}()
     link_names = Set()
+
     for body in bodies(mechanism)
         if randomize_colors
             color = RGBA{Float64}(rand(3)..., 0.5)
@@ -122,16 +127,16 @@ function create_geometry(mechanism; show_inertias::Bool=false, randomize_colors:
             ellipsoid, ellipsoid_frame = inertial_ellipsoid(mechanism, body)
             vis_data[ellipsoid_frame] = [GeometryData(ellipsoid, color)]
         else
-            frame = default_frame(body)
-            vis_data[frame] = [GeometryData(HyperSphere{3, Float64}(
-                zero(Point{3, Float64}), box_width), color)]
+            for joint in out_joints(body, mechanism)
+                vis_data[frame_before(joint)] = [GeometryData(HyperSphere{3, Float64}(
+                    zero(Point{3, Float64}), box_width), color)]
+            end
         end
-        if !isroot(body, mechanism)
-            for joint in joints_to_children(body, mechanism)
-                geom, geom_frame = create_geometry_for_translation(mechanism,
-                                                                   body,
-                                                                   joint,
-                                                                   box_width / 2)
+        frames = body_fixed_joint_frames[body]
+        for (i, framei) in enumerate(frames)
+            for j = i + 1 : length(frames)
+                framej = frames[j]
+                geom, geom_frame = create_frame_to_frame_geometry(mechanism, body, framei, framej, box_width / 2)
                 vis_data[geom_frame] = [GeometryData(geom, color)]
             end
         end


### PR DESCRIPTION
Draw cylinders between all joint frames fixed to a body.

Draw spheres at frames before all joints (not only tree joints).

Fixes #21.