### PR TITLE
Fix parsing for URDFs with named colors

### DIFF
--- a/src/parse_urdf.jl
+++ b/src/parse_urdf.jl
@@ -83,7 +83,7 @@ function parse_geometry{T}(::Type{T}, xml_geometry::XMLElement, package_path)
     geometries
 end
 
-function parse_material{T}(::Type{T}, xml_material, named_colors::Dict{String, RGBA{T}})
+function parse_material{T}(::Type{T}, xml_material, named_colors::Dict{String, RGBA{T}}=Dict{String, RGBA{T}}())
     default = "0.7 0.7 0.7 1."
     if xml_material == nothing
         color = RGBA{T}(parse_vector(T, nothing, "rgba", default)...)


### PR DESCRIPTION
For example the pr2.urdf in Drake.

Adding the default argument to `parse_material` allows the calll at https://github.com/rdeits/RigidBodyTreeInspector.jl/blob/a575dbd9245a749858121691f5b1f88e13265f39/src/parse_urdf.jl#L135 to succeed.
