### PR TITLE
Adapt to camelcase -> underscore changes in RigidBodyDynamics

### DIFF
--- a/examples/demo.ipynb
+++ b/examples/demo.ipynb
@@ -169,7 +169,7 @@
     "    nothing\n",
     "end\n",
     "integrator = MuntheKaasIntegrator(damped_dynamics!, runge_kutta_4(Float64), DrakeVisualizerSink(vis))\n",
-    "integrate(integrator, state, 10., 1e-3, maxRealtimeRate = 1.)"
+    "integrate(integrator, state, 10., 1e-3, max_realtime_rate = 1.)"
    ]
   },
   {

--- a/src/animate.jl
+++ b/src/animate.jl
@@ -11,8 +11,8 @@ end
 one(::Type{InterpolatableArray{A}}) where {A} = 1
 *(n::Number, a::InterpolatableArray) = n * a.data
 
-normalize_configuration!(jointType::JointType, q) = nothing
-function normalize_configuration!(jointType::QuaternionFloating, q)
+normalize_configuration!(joint_type::JointType, q) = nothing
+function normalize_configuration!(joint_type::QuaternionFloating, q)
     n = norm(q[1:4])
     for i = 1:4
         q[i] /= n

--- a/src/animate.jl
+++ b/src/animate.jl
@@ -42,7 +42,7 @@ function animate(vis::Visualizer, mechanism::Mechanism{Float64},
         for joint in tree_joints(mechanism)
             q_range = RigidBodyDynamics.configuration_range(state, joint)
             q_joint = q[q_range]
-            normalize_configuration!(joint.jointType, q_joint)
+            normalize_configuration!(joint_type(joint), q_joint)
             configuration(state, joint)[:] = q_joint
         end
         setdirty!(state)

--- a/src/manipulate.jl
+++ b/src/manipulate.jl
@@ -6,18 +6,18 @@ the rotation in exponential map form. Those three sliders then have to be
 converted into a quaternion to set the joint configuration. We do this because
 interacting with the four components of a quaternion is quite unintuitive.
 """
-function joint_configuration(jointType::RigidBodyDynamics.QuaternionFloating,
+function joint_configuration(joint_type::RigidBodyDynamics.QuaternionFloating,
                              sliders::NTuple{6, T}) where T
     q = collect(sliders)
     quat = Quat(RodriguesVec(q[1], q[2], q[3]))
     vcat([quat.w; quat.x; quat.y; quat.z], q[4:6])
 end
-joint_configuration(jointType::RigidBodyDynamics.OneDegreeOfFreedomFixedAxis,
+joint_configuration(joint_type::RigidBodyDynamics.OneDegreeOfFreedomFixedAxis,
                     sliders::NTuple{1, T}) where {T} = collect(sliders)
-joint_configuration(jointType::RigidBodyDynamics.Fixed, sliders::Tuple{}) = []
-num_sliders(jointType::RigidBodyDynamics.OneDegreeOfFreedomFixedAxis) = 1
-num_sliders(jointType::RigidBodyDynamics.QuaternionFloating) = 6
-num_sliders(jointType::RigidBodyDynamics.Fixed) = 0
+joint_configuration(joint_type::RigidBodyDynamics.Fixed, sliders::Tuple{}) = []
+num_sliders(joint_type::RigidBodyDynamics.OneDegreeOfFreedomFixedAxis) = 1
+num_sliders(joint_type::RigidBodyDynamics.QuaternionFloating) = 6
+num_sliders(joint_type::RigidBodyDynamics.Fixed) = 0
 num_sliders(joint::RigidBodyDynamics.Joint) = num_sliders(joint_type(joint))
 
 """

--- a/src/manipulate.jl
+++ b/src/manipulate.jl
@@ -18,7 +18,7 @@ joint_configuration(jointType::RigidBodyDynamics.Fixed, sliders::Tuple{}) = []
 num_sliders(jointType::RigidBodyDynamics.OneDegreeOfFreedomFixedAxis) = 1
 num_sliders(jointType::RigidBodyDynamics.QuaternionFloating) = 6
 num_sliders(jointType::RigidBodyDynamics.Fixed) = 0
-num_sliders(joint::RigidBodyDynamics.Joint) = num_sliders(joint.jointType)
+num_sliders(joint::RigidBodyDynamics.Joint) = num_sliders(joint_type(joint))
 
 """
     manipulate!(callback::Function, state::MechanismState)
@@ -42,7 +42,7 @@ function manipulate!(callback::Function, state::MechanismState)
     foreach(map(Interact.signal, widgets)...) do q...
         slider_index = 1
         for (i, joint) in enumerate(mech_joints)
-            configuration(state, joint)[:] = joint_configuration(joint.jointType, q[slider_index:(slider_index+num_sliders_per_joint[i]-1)])
+            configuration(state, joint)[:] = joint_configuration(joint_type(joint), q[slider_index:(slider_index+num_sliders_per_joint[i]-1)])
             slider_index += num_sliders_per_joint[i]
         end
         setdirty!(state)


### PR DESCRIPTION
Ref https://github.com/tkoolen/RigidBodyDynamics.jl/pull/313.

Note: everything works on v0.0.3 of RigidBodyDynamics as well, except for the `max_realtime_rate` kwarg passed into the `simulate` function in the demo notebook.